### PR TITLE
Update Gemfile, commit Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'http://rubygems.org'
 ruby '2.3.1'
 
-gem 'twitter_ebooks'
+gem 'httparty', '~> 0.14.0'
+gem 'twitter_ebooks', '~> 3.1', '>= 3.1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,81 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    awesome_print (1.7.0)
+    buftok (0.2.0)
+    coderay (1.1.1)
+    domain_name (0.5.20161021)
+      unf (>= 0.0.5, < 1.0.0)
+    engtagger (0.2.1)
+    equalizer (0.0.10)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    fast-stemmer (1.0.2)
+    gingerice (1.2.2)
+      addressable
+      awesome_print
+    highscore (1.2.1)
+      whatlanguage (>= 1.0.0)
+    htmlentities (4.3.4)
+    http (1.0.4)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (1.0.1)
+    http_parser.rb (0.6.0)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
+    json (1.8.3)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    method_source (0.8.2)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
+    naught (1.1.0)
+    oauth (0.5.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    public_suffix (2.0.4)
+    rufus-scheduler (3.2.2)
+    simple_oauth (0.3.1)
+    slop (3.6.0)
+    thread_safe (0.3.5)
+    twitter (5.16.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (= 0.0.10)
+      faraday (~> 0.9.0)
+      http (~> 1.0)
+      http_parser.rb (~> 0.6.0)
+      json (~> 1.8)
+      memoizable (~> 0.4.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
+    twitter_ebooks (3.1.6)
+      engtagger
+      fast-stemmer
+      gingerice
+      highscore
+      htmlentities
+      oauth
+      pry
+      rufus-scheduler
+      twitter (~> 5.15)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+    whatlanguage (1.0.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  httparty (~> 0.14.0)
+  twitter_ebooks (~> 3.1, >= 3.1.6)


### PR DESCRIPTION
This adds httparty, and sets the range of twitter_ebooks versions. I also added the Gemfile.lock to fix the specific versions installed for me. I think this covers everything!

Since twitter_ebooks has had breaking changes in the past, I thought setting the range of versions was prudent.